### PR TITLE
Add builds folder and .DS_Store files to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ sysinfo.txt
 # Builds
 *.apk
 *.unitypackage
+
+# Builds Directory
+Builds/*
+
+# MAC DS_Store files
+*.DS_Store


### PR DESCRIPTION
1. Set the title to exactly what you are adding.

2. Which team is this for?
Administration

3. Give a short description of what you are implementing:
Added two lines to the .gitignore, One to ignore .DS_Store files made by Macs, the other to create a 'Builds' folder but ignore everything inside it.